### PR TITLE
Extend browser capabilities config to allow two new options:

### DIFF
--- a/lib/taskRunner.js
+++ b/lib/taskRunner.js
@@ -36,14 +36,17 @@ util.inherits(TaskRunner, EventEmitter);
 TaskRunner.prototype.run = function() {
   var deferred = q.defer();
 
-  var maxRetries = 3;
+  var maxRetries = this.task.capabilities.maxRetries || 0;
   var retries = 0;
 
   var self = this;
 
-  // Running processes in fork is much more predictable when we want to retry them. Using it by default
-  // even with only 1 spec in queue.
-  this.runInFork = true;
+  // - Running processes in fork is much more predictable when we want to retry them. Using it by default
+  //   even with only 1 spec in queue.
+  // - The issue is reporting behavior is different and cannot be so easily controlled in "forked" mode.
+  // - When `maxRetries` positive we always run processes in fork mode. It's easier to retry them.
+  if (maxRetries > 0)
+    this.runInFork = true;
 
   var taskLogger = new TaskLogger(this.task, process.pid);
   var runnerFn = this.runInFork ? this._runForked : this._runNormal;
@@ -113,15 +116,18 @@ TaskRunner.prototype._runForked = function(runResults) {
   // TODO: It's a little ugly carry logger like this
   runResults.taskLogger = taskLogger;
 
-  // stdout pipe
-  childProcess.stdout.on('data', function(data) {
-    taskLogger.log(data);
-  });
+  var onData = function(stream) {
+    return function(data) {
+      if (self.task.capabilities.shardTestBufferingDisabled)
+        stream.write(data)
+      else
+        taskLogger.log(data);
+    }
+  };
 
-  // stderr pipe
-  childProcess.stderr.on('data', function(data) {
-    taskLogger.log(data);
-  });
+  // stdout and stderr pipes
+  childProcess.stdout.on('data', onData(process.stdout));
+  childProcess.stderr.on('data', onData(process.stderr));
 
   childProcess.on('message', function(m) {
     // console.log('zzz msg', self.task.taskId, m.event);


### PR DESCRIPTION
- maxRetries: sets number of allowed retries
- shardTestBufferingDisabled: do not buffer output from forked processes
